### PR TITLE
Fixed two spelling errors

### DIFF
--- a/emulator/OsmoseCore.cpp
+++ b/emulator/OsmoseCore.cpp
@@ -118,7 +118,7 @@ OsmoseCore::OsmoseCore(const char *rom_f,  unsigned int *output, OsmoseConfigura
 		catch(string error)
 		{
 			QLogWindow::getInstance()->appendLog(error);
-			QLogWindow::getInstance()->appendLog("Sound disabled. Sound recording wont work.");
+			QLogWindow::getInstance()->appendLog("Sound disabled. Sound recording won't work.");
 			sndThread = NULL;
 			emu_opt.sound = false;
 		}

--- a/emulator/SoundThread.cpp
+++ b/emulator/SoundThread.cpp
@@ -120,7 +120,7 @@ void SoundThread::play()
 	{
 		if (frames_to_deliver == -EPIPE)
 		{
-			fprintf (stderr, "an xrun occured\n");
+			fprintf (stderr, "an xrun occurred\n");
 		}
 
 		else


### PR DESCRIPTION
Original patch: https://sources.debian.net/src/osmose-emulator/0.9.96-dfsg-1/debian/patches/typo.patch/

I used git's feature to define a custom author to credit @coringao for this patch.
