### PR TITLE
Codespell the whole source to fix typos + delete[] change

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -5,9 +5,10 @@ Copyright 2001-2011 Bruno Vedder
 Main developers:
   Bruno Vedder, copyright holder
 
-Contributors:
+Contributors (2013-2016):
   Mathieu Comandon
   Rémi Verschelde
+  Carlos Donizete Froes
 
 -------------------------
 

--- a/OsmoseConfigurationFile.cpp
+++ b/OsmoseConfigurationFile.cpp
@@ -397,7 +397,7 @@ void OsmoseConfigurationFile::save()
 }
 
 /**
- * Restore Osmose default configuration of Pathes and key mapping.
+ * Restore Osmose default configuration of Paths and key mapping.
  */
 void OsmoseConfigurationFile::resetToDefault()
 {
@@ -437,7 +437,7 @@ void OsmoseConfigurationFile::resetToDefault()
 }
 
 /**
- * Restore Osmose default configuration of Pathes and key mapping and save
+ * Restore Osmose default configuration of Paths and key mapping and save
  * the configuration file.
  */
 void OsmoseConfigurationFile::createDefautConfigurationFile()

--- a/Pthreadcpp.cpp
+++ b/Pthreadcpp.cpp
@@ -89,7 +89,7 @@ int Thread::start(void *param)
 /**
  * This static method is here because pthread_create cannot take member function
  * as start_routine, except if it's static. So we made a private static that can
- * only be called by non static member start(). EntryPoint method recieved a this
+ * only be called by non static member start(). EntryPoint method received a this
  * pointer, and use it to call the runnable run() method.
  */
 void *Thread::entryPoint(void *instance)

--- a/Pthreadcpp.h
+++ b/Pthreadcpp.h
@@ -39,7 +39,7 @@
  * Tiny utility class to benefit from C++ auto destruction of objects.
  * Creating a LOCAL Mutex object will lock the mutex. Leaving the method
  * will destroy the object automatically and free the mutex. So in order
- * to get a method thread safe, simply add at the begining :
+ * to get a method thread safe, simply add at the beginning:
  * MutexLocker(the_mutex);
  */
 class MutexLocker

--- a/QOsmoseConfiguration.cpp
+++ b/QOsmoseConfiguration.cpp
@@ -63,7 +63,7 @@ QOsmoseConfiguration::~QOsmoseConfiguration()
  *
  * This slot is called when the tool button is clicked. It then open a file
  * selection dialog to get an existing directory to store Battery Backed RAM.
- * The corresponding QLineEdit is also updated with the choosen path.
+ * The corresponding QLineEdit is also updated with the chosen path.
  */
 void QOsmoseConfiguration::selectBBRPath()
 {
@@ -82,7 +82,7 @@ void QOsmoseConfiguration::selectBBRPath()
  *
  * This slot is called when the tool button is clicked. It then open a file
  * selection dialog to get an existing directory to store screenshots.
- * The corresponding QLineEdit is also updated with the choosen path.
+ * The corresponding QLineEdit is also updated with the chosen path.
  */
 void QOsmoseConfiguration::selectScreenshotPath()
 {
@@ -101,7 +101,7 @@ void QOsmoseConfiguration::selectScreenshotPath()
  *
  * This slot is called when the tool button is clicked. It then open a file
  * selection dialog to get an existing directory to store save states.
- * The corresponding QLineEdit is also updated with the choosen path.
+ * The corresponding QLineEdit is also updated with the chosen path.
  */
 void QOsmoseConfiguration::selectSaveStatePath()
 {
@@ -120,7 +120,7 @@ void QOsmoseConfiguration::selectSaveStatePath()
  *
  * This slot is called when the tool button is clicked. It then open a file
  * selection dialog to get an existing directory to store ripped tiles.
- * The corresponding QLineEdit is also updated with the choosen path.
+ * The corresponding QLineEdit is also updated with the chosen path.
  */
 void QOsmoseConfiguration::selectTileRipPath()	
 {
@@ -139,7 +139,7 @@ void QOsmoseConfiguration::selectTileRipPath()
  *
  * This slot is called when the tool button is clicked. It then open a file
  * selection dialog to get an existing directory to store ripped sounds.
- * The corresponding QLineEdit is also updated with the choosen path.
+ * The corresponding QLineEdit is also updated with the chosen path.
  */
 void QOsmoseConfiguration::selectSoundRipPath()
 {
@@ -215,7 +215,7 @@ void QOsmoseConfiguration::completeConnections()
  */
 void QOsmoseConfiguration::synchronizeWithConfiguration()
 {
-	// Synchronize pathes.
+	// Synchronize paths.
 	screenshotsPathLineEdit->setText(ocf->getScreenshotPath().c_str());  
 	bbrPathLineEdit->setText(ocf->getBBRPath().c_str());
 	saveStatePathLineEdit->setText(ocf->getSaveStatePath().c_str());

--- a/cpu/Z80.cpp
+++ b/cpu/Z80.cpp
@@ -22,7 +22,7 @@
  *
  * Description: This class implements Z80 cpu emulator. It's table driven, and all
  * opcodes are supported. Not that undocumented flags are not totaly supported.
- * In these files are defined almost all ALU, and Shift operations. Adress mode
+ * In these files are defined almost all ALU, and Shift operations. Address mode
  * getters and setters are define in Z80.h as statics methods.
  *
  * Author: Vedder Bruno

--- a/cpu/Z80.h
+++ b/cpu/Z80.h
@@ -48,7 +48,7 @@
 #define     XF 0x08		/* Undoc flag 	*/
 #define     VF 0x04		/* Overflow 	*/
 #define     PF 0x04		/* Parity	*/
-#define     NF 0x02		/* Add substract*/
+#define     NF 0x02		/* Add subtract */
 #define     CF 0x01		/* Carry 	*/
 
 /* Save state data structure. */
@@ -89,7 +89,7 @@ class Z80Environment
             return 0xFF;
         }
 
-        /* 8 bits write operation adress, value. */
+        /* 8 bits write operation address, value. */
         virtual void wr8( u16 , u8 )
         {
         }
@@ -116,7 +116,7 @@ class Z80Environment
             return 0xFF;
         }
 
-        /* 8 bits write IO operation adress, value. */
+        /* 8 bits write IO operation address, value. */
         virtual void out( u16 , u8  )
         {
         }
@@ -145,7 +145,7 @@ class Z80 : public DebugEventThrower, public ImplementsSaveState
         u8 Rbit7;                   /* Use to store bit 7 of R  */
         u8 IM;                      /* Interrupt mode */
         u16 PC,IX,IY,SP;            /* PC,Stack, indexes registers. 	*/
-        u16 IXd, IYd;               /* Used for XY+d adressing mode. */
+        u16 IXd, IYd;               /* Used for XY+d addressing mode. */
         bool IFF1,IFF2;             /* NMI/IRQ interrupt flip flop. */
         bool cpuHalted;             /* CPU state vs Halt instruction.*/
         u32 cycleCount;             /* Increase when running CPU. 	 */
@@ -297,7 +297,7 @@ class Z80 : public DebugEventThrower, public ImplementsSaveState
             env.wr8(getHL(),val);    /* write u8 in (HL) */
         }
 
-        /* 8 bit read/write throught (IX+d) and (IY+d). Warning: PC is not incremented !  */
+        /* 8 bit read/write through (IX+d) and (IY+d). Warning: PC is not incremented! */
         u8    getIXdi()
         {
             return env.rd8((u16)(IX + (s8)env.rd8(PC)));

--- a/emulator/IOMapper.cpp
+++ b/emulator/IOMapper.cpp
@@ -217,7 +217,7 @@ void IOMapper::out8(unsigned port, unsigned char value)
         }
     }
 #ifdef VDP_VERBOSE
-    cout << "Unkown port "<< hex << setw(2) << setfill('0') << (int)port << " written with value " << hex << setw(2) << setfill('0') << (int)value << endl;
+    cout << "Unknown port "<< hex << setw(2) << setfill('0') << (int)port << " written with value " << hex << setw(2) << setfill('0') << (int)value << endl;
 #endif
 
 }
@@ -244,14 +244,14 @@ unsigned char IOMapper::in8(unsigned port)
         if (port & BIT0) 	// Read H counter port.
         {
 //#ifdef VDP_VERBOSE
-            cout << "NOT IMPLEMENTED: VDP port H COUTNER 0x7F read."<< endl;
+            cout << "NOT IMPLEMENTED: VDP port H COUNTER 0x7F read."<< endl;
 //#endif
             return 0xFF;
         }
         else 			// Read on VDP Vertical counter
         {
 #ifdef VDP_VERBOSE
-            cout << "VDP, port V COUTNER 0x7E read."<< endl;
+            cout << "VDP, port V COUNTER 0x7E read."<< endl;
 #endif
             return vdp.v_counter;
         }
@@ -306,5 +306,5 @@ unsigned char IOMapper::in8(unsigned port)
         }
         return portPAD1;
     }
-    cout << "Unkown port "<< hex << setw(2) << setfill('0') << (int)port << " read."<< endl;
+    cout << "Unknown port "<< hex << setw(2) << setfill('0') << (int)port << " read."<< endl;
 }

--- a/emulator/IOMapper_GG.cpp
+++ b/emulator/IOMapper_GG.cpp
@@ -81,14 +81,14 @@ unsigned char IOMapper_GG::in8(unsigned  port)
         if (port & BIT0) 	// Read H counter port.
         {
 #ifdef VDP_VERBOSE
-            cout << "NOT IMPLEMENTED: VDP port H COUTNER 0x7F read."<< endl;
+            cout << "NOT IMPLEMENTED: VDP port H COUNTER 0x7F read."<< endl;
 #endif
             return 0xFF;
         }
         else 			// Read on VDP Vertical counter
         {
 #ifdef VDP_VERBOSE
-            cout << "VDP, port V COUTNER 0x7E read."<< endl;
+            cout << "VDP, port V COUNTER 0x7E read."<< endl;
 #endif
             return vdp.v_counter;
         }
@@ -143,7 +143,7 @@ unsigned char IOMapper_GG::in8(unsigned  port)
         }
         return portPAD1;
     }
-    cout << "Unkown port "<< hex << setw(2) << setfill('0') << (int)port << " read."<< endl;
+    cout << "Unknown port "<< hex << setw(2) << setfill('0') << (int)port << " read."<< endl;
 }
 
 void IOMapper_GG::out8(unsigned  address, unsigned  char data)

--- a/emulator/MemoryMapper.cpp
+++ b/emulator/MemoryMapper.cpp
@@ -41,7 +41,7 @@
 extern Options opt;
 
 /*--------------------------------------------------------------------*/
-/* Class constructor. It immediatly load a given rom, and updates     */
+/* Class constructor. It immediately load a given rom, and updates    */
 /* Memory mapper variables.					      */
 /*--------------------------------------------------------------------*/
 MemoryMapper::MemoryMapper(const char *rom_file, OsmoseConfigurationFile *conf)
@@ -248,7 +248,7 @@ void MemoryMapper::reset()
 void MemoryMapper::dump(unsigned char bank_n)
 {
 
-    int adress = 0;
+    int address = 0;
     if (bank_n >= bank_nbr)
     {
         cout << "Warning, cannot dump bank " << bank_n << " This bank does not exists." << endl;
@@ -261,7 +261,7 @@ void MemoryMapper::dump(unsigned char bank_n)
         cout << hex << setw(4) << setfill('0') << (i*16)  << ": ";
         for (int o=0;o<16;o++)
         {
-            cout << hex << setw(2) << setfill('0') <<(int) read_map[bank_n][adress++] << " ";
+            cout << hex << setw(2) << setfill('0') <<(int) read_map[bank_n][address++] << " ";
         }
         cout << endl;
     }
@@ -274,7 +274,7 @@ void MemoryMapper::dump(unsigned char bank_n)
 /*------------------------------------------------------------*/
 void MemoryMapper::dump_page(unsigned char bank_n)
 {
-    int adress = 0;
+    int address = 0;
     if (bank_n > 2)
     {
         cout << "Warning, cannot dump page " << bank_n << " This page does not exists." << endl;
@@ -287,7 +287,7 @@ void MemoryMapper::dump_page(unsigned char bank_n)
         cout << hex << setw(4) << setfill('0') << (i*16)  << ": ";
         for (int o=0;o<8;o++)
         {
-            cout << hex << setw(2) << setfill('0') <<(int) read_map[bank_n][adress++] << " ";
+            cout << hex << setw(2) << setfill('0') <<(int) read_map[bank_n][address++] << " ";
         }
         cout << endl;
     }
@@ -914,7 +914,7 @@ void MemoryMapper::save_battery_backed_memory(string filename)
 /*------------------------------------------------------------*/
 /* This method computes CRC32 calculation on an uncompressed  */
 /* ROM. It will be use for ROM that need special options, e.g */
-/* -cm CodeMaster Mapper ect...								  */
+/* -cm CodeMaster Mapper etc...                               */
 /*------------------------------------------------------------*/
 unsigned int MemoryMapper::getCRC32(unsigned char *buffer, unsigned int len)
 {

--- a/emulator/MemoryMapper.h
+++ b/emulator/MemoryMapper.h
@@ -63,7 +63,7 @@ enum Mapper
     KoreanMapper
 };
 
-/* Enumeration of adressing space areas types that could be read/written. */
+/* Enumeration of addressing space areas types that could be read/written. */
 enum Area_type
 {
     Cartridge,
@@ -75,8 +75,8 @@ enum Area_type
 /*---------------------------------------------------------------------------*/
 /*              Structure to save Memory mapper state.                       */
 /* It's necessary to save paging registers, but it's Also required to save   */
-/* the bank mapping, instead of doing fake wr8 on adress 0xFFFC-0xFFFF to    */
-/* get the correct mapping (order dependant for FFFC). As RAM pointer are    */
+/* the bank mapping, instead of doing fake wr8 on address 0xFFFC-0xFFFF to   */
+/* get the correct mapping (order dependent for FFFC). As RAM pointer are    */
 /* not identical from different process, we save the area type of memory     */
 /* plus the bloc (8Ko) number inside the area.                               */
 /* e.g: read_map[0] pointing to cartridge 0x2000 will be saved as :          */

--- a/emulator/OsmoseCore.cpp
+++ b/emulator/OsmoseCore.cpp
@@ -283,7 +283,7 @@ bool OsmoseCore::captureTiles()
 	}
 	
 	/* Deallocate buffer. */
-	delete local_buffer;
+	delete[] local_buffer;
 	
 	return true;
 }

--- a/emulator/OsmoseCore.cpp
+++ b/emulator/OsmoseCore.cpp
@@ -377,7 +377,7 @@ bool OsmoseCore::captureScreen()
 /* This method toggles the sound recording on and OFF. The filename   */
 /* is game_name +x .wav , where x is the number of taken sound shot,  */
 /* which is incremented every time recordSounds(OFF) is called.       */
-/* Return : true if operation was successfull, false otherwise. 	  */
+/* Return: true if operation was successful, false otherwise.         */
 /*--------------------------------------------------------------------*/
 bool OsmoseCore::startRecordingSounds()
 {
@@ -402,7 +402,7 @@ bool OsmoseCore::startRecordingSounds()
 /* This method toggles the sound recording on and OFF. The filename   */
 /* is game_name +x .wav , where x is the number of taken sound shot,  */
 /* which is incremented every time recordSounds(OFF) is called.       */
-/* Return : true if operation was successfull, false otherwise. 	  */
+/* Return: true if operation was successful, false otherwise.         */
 /*--------------------------------------------------------------------*/
 void OsmoseCore::stopRecordingSounds()
 {

--- a/emulator/SN76489.cpp
+++ b/emulator/SN76489.cpp
@@ -32,7 +32,7 @@
 #include "Bits.h"
 //#include <stdio.h>
 
-/* Values ripped from MEKA. They've been controled against a real SMS.*/
+/* Values ripped from MEKA. They've been controlled against a real SMS.*/
 const u16 SN76489::volume_table[16] = {892*5, 892*5, 892*5, 760*5, 623*5, 497*5, 404*5, 323*5, 257*5, 198*5, 159*5, 123*5,  96*5,  75*5,  60*5, 0};
 
 #define MAX_OUTPUT 0x7FFF
@@ -70,7 +70,7 @@ void SN76489::writePort(u8 value)
         }
         else
         {
-            /* Like said in Maxim's doc, immediatly update tone registers.*/
+            /* Like said in Maxim's doc, immediately update tone registers.*/
             freqDiv_[channel] = (freqDiv_[channel] & 0x3F0) | (value & 0xF);
 
             /*
@@ -146,7 +146,7 @@ void SN76489::writePort(u8 value)
 
 
 /*-------------------------------------------------------------*/
-/* This method resets the PSG to it's intial values            */
+/* This method resets the PSG to it's initial values            */
 /*-------------------------------------------------------------*/
 void SN76489::reset()
 {

--- a/emulator/SmsDebugger.cpp
+++ b/emulator/SmsDebugger.cpp
@@ -594,7 +594,7 @@ void SmsDebugger::exec_cmd(char *cmd, int param1, int  param2)
 
 void SmsDebugger::unknownCommand()
 {
-    cout << "Unkown command." << endl;
+    cout << "Unknown command." << endl;
 }
 
 void SmsDebugger::setScanlineBreakpoint(int scanline)

--- a/emulator/SoundThread.cpp
+++ b/emulator/SoundThread.cpp
@@ -84,7 +84,7 @@ void* SoundThread::run(void *p)
 				struct timespec rqtp;
 				rqtp.tv_sec = 0;
 				rqtp.tv_nsec = 1000000; // 1 millisecond.
-				nanosleep(&rqtp, NULL);	// NULL = dont care about remaining time if interrupted.
+				nanosleep(&rqtp, NULL);	// NULL = don't care about remaining time if interrupted.
 			break;
 
 			default:

--- a/emulator/VDP.h
+++ b/emulator/VDP.h
@@ -124,7 +124,7 @@ class VDP : public DebugEventThrower, public ImplementsSaveState
         unsigned char  vdp_status;                     // used with portBF read.
         unsigned char  v_counter;                      // Vertical scanline ctr.
         unsigned char *v_cnt;		           		   // point ntsc/pal vcount values.
-        int line;                                      // Line actualy drawn.
+        int line;                                      // Line actually drawn.
         unsigned char     i_counter;                   // Interrupt Line counter.
         unsigned char  rd_data_port_buffer;		   	   // Buffer used in read data port.
         bool irq_line_pending;


### PR DESCRIPTION
It would have been simpler for me to just run codespell myself and commit the changes, but I wanted to preserve @coringao's credits, so here it is.
