### PR TITLE
Fix sound on recent Debian (pulseaudio)

### DIFF
--- a/emulator/OsmoseCore.cpp
+++ b/emulator/OsmoseCore.cpp
@@ -111,7 +111,7 @@ OsmoseCore::OsmoseCore(const char *rom_f,  unsigned int *output, OsmoseConfigura
     {
         try
         {
-            sndThread = new SoundThread("plughw:0,0", p->getFIFOSoundBuffer());
+            sndThread = new SoundThread("default", p->getFIFOSoundBuffer());
             sndThread->start();  // Start thread, not playing!
             string msg = "Creating SoundThread";
             QLogWindow::getInstance()->appendLog(msg);

--- a/emulator/SoundThread.cpp
+++ b/emulator/SoundThread.cpp
@@ -146,11 +146,9 @@ int SoundThread::playback_callback (snd_pcm_sframes_t nframes)
     int err;
 
     //printf ("playback callback called with %d frames\n", (int)nframes);
-    void *channelsbuffer[1];
-    channelsbuffer[0] = &samplebuffer;
     sndFIFO->read(samplebuffer, nframes);
 
-    if ((err = snd_pcm_writen(playback_handle, (void **)channelsbuffer, nframes)) < 0)
+    if ((err = snd_pcm_writei(playback_handle, samplebuffer, nframes)) < 0)
     {
         fprintf (stderr, "write failed (%s)\n", snd_strerror (err));
     }
@@ -222,14 +220,6 @@ void SoundThread::initAlsa()
     if ((err = snd_pcm_hw_params_any (playback_handle, hw_params)) < 0)
     {
         oss << "cannot initialize hardware parameter structure: " << snd_strerror (err) << endl;
-        throw oss.str();
-    }
-
-
-    // Set Sample are NON Interleaved (mono!)
-    if ((err = snd_pcm_hw_params_set_access (playback_handle, hw_params, SND_PCM_ACCESS_RW_NONINTERLEAVED)) < 0)
-    {
-        oss << "cannot set access type: " << snd_strerror (err) << endl;
         throw oss.str();
     }
 


### PR DESCRIPTION
Hi,

First and foremost, great job! Very interesting! I am now trying to emulate a verilog design of the sound chip with verilator using Osmose in order to replace my fried 315-5124 by an FPGA (yeah, it's a bit silly but I also want to learn verilog!). However, I had to do few fixes to have your emulator working:

- The plugdev device seems to not be available on my machine. Thus, I replaced it by the "default" alsa interface.
-Also, the interleaved mode was not supported on my computer. Then, I changed to interleaved mode write but since we are using only mono it shouldn't be a problem.

Cheers,
Kevin